### PR TITLE
Add support for replacement in template literals.

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,5 +1,5 @@
 // replace
-import {StringLiteral} from "@swc/core";
+import {StringLiteral, TemplateElement} from "@swc/core";
 
 export function replace(mark: string, placeholder: string, code: string) {
   const re = new RegExp(mark, 'g')
@@ -36,4 +36,9 @@ export function replaceInStringLiteral(literal: StringLiteral, base: string, pla
   const prefix = withStartQuote ? quoteMark : '';
 
   return `${prefix}${transformedStr}${quoteMark}`;
+}
+
+export function replaceInTemplateElement(element: TemplateElement, base: string, placeholder: string): string {
+  const regex = new RegExp(base, 'g');
+  return element.raw.replace(regex, () => '/${' + placeholder + '}/');
 }

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -39,4 +39,16 @@ describe('transform', () => {
     const result = await transformChunk(code, options);
     expect(result).toEqual(`var reportError=function(e){return "Couldn't find "+window.__dynamic_base__+"/assets/some.file or "+window.__dynamic_base__+"/assets/some_other.file";}`);
   })
+
+  test('transformChunk-template-literal', async () => {
+    const code = 'var foo=function(part1,part2){return \`${part1}/__dynamic_base__/test/${part2}\`;}';
+    const result = await transformChunk(code, options);
+    expect(result).toEqual('var foo=function(part1,part2){return \`$\{part1}/${window.__dynamic_base__}/test/${part2}\`;}');
+  })
+
+  test('transformChunk-template-literal-with-multiple-elements', async () => {
+    const code = "var reportError=function(e){return \`Couldn't find /__dynamic_base__/assets/${filename1} or /__dynamic_base__/assets/${filename2}\`;}";
+    const result = await transformChunk(code, options);
+    expect(result).toEqual("var reportError=function(e){return `Couldn't find /${window.__dynamic_base__}/assets/${filename1} or /${window.__dynamic_base__}/assets/${filename2}`;}");
+  })
 })


### PR DESCRIPTION
Template literals have lead to problems for some users, although they seem to occur very rarely in the transpiled code vite outputs. Still, I think it is pertinent to support replacing dynamic base strings in template literals.

(This addresses issue #8)