### PR TITLE
Fix failing transformations due to wrong string / template order.

### DIFF
--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -6,9 +6,7 @@ import Visitor from "@swc/core/Visitor";
  * needle in their value.
  */
 export class StringCollector extends Visitor {
-
-    public baseStringLiterals: StringLiteral[] = [];
-    public baseTemplateElements: TemplateElement[] = [];
+    public matchingStrings: (StringLiteral|TemplateElement)[] = [];
     private readonly needle: string;
 
     constructor(needle: string) {
@@ -17,9 +15,8 @@ export class StringCollector extends Visitor {
     }
 
     visitStringLiteral(n: StringLiteral): StringLiteral {
-
         if (n.value.indexOf(this.needle) !== -1) {
-            this.baseStringLiterals.push(n);
+            this.matchingStrings.push(n);
         }
 
         return super.visitStringLiteral(n);
@@ -27,8 +24,8 @@ export class StringCollector extends Visitor {
 
     visitTemplateLiteral(n: TemplateLiteral): Expression {
         for(const q of n.quasis) {
-            if (q.raw.indexOf(this.needle) !== 1) {
-                this.baseTemplateElements.push(q);
+            if (q.raw.indexOf(this.needle) !== -1) {
+                this.matchingStrings.push(q);
             }
         }
 
@@ -79,5 +76,5 @@ export function collectMatchingStrings(needle: string, ast: ModuleItem[]): (Stri
     const visitor = new StringCollector(needle);
     visitor.visitModuleItems(ast);
 
-    return [ ...visitor.baseStringLiterals, ...visitor.baseTemplateElements ];
+    return visitor.matchingStrings;
 }

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -51,4 +51,10 @@ describe('transform', () => {
     const result = await transformChunk(code, options);
     expect(result).toEqual("var reportError=function(e){return `Couldn't find /${window.__dynamic_base__}/assets/${filename1} or /${window.__dynamic_base__}/assets/${filename2}`;}");
   })
+
+  test('transformChunk-mixed-strings-and-templates', async () => {
+    const code = "const someString = \"Hello World!\"; const someTemplate = \`${Math.random()} is a random number.\`; const myPath = `/${someVar}/__dynamic_base__/image.png`; const strPath = '/assets/__dynamic_base__/image2.png';";
+    const result = await transformChunk(code, options);
+    expect(result).toEqual("const someString = \"Hello World!\"; const someTemplate = \`${Math.random()} is a random number.\`; const myPath = `/${someVar}/${window.__dynamic_base__}/image.png`; const strPath = '/assets'+window.__dynamic_base__+'/image2.png';")
+  })
 })


### PR DESCRIPTION
This fixes issue #29.

Sorry for this, neither my manual tests nor the unit tests caught this, because I did not think to mix template literals and string literals. I've added a test to hopefully catch such a regression the next time.