### PR TITLE
fix: failed getElementById in @micro-zoe/micro-app proxy sandbox mode

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -50,19 +50,23 @@ export function transformLegacyHtml(code: string, options: TransformOptions) {
   content = replaceImport(publicPath, content)
   const document = parse(content, { comment: true })
   const legacyPolyfill = document.getElementById('vite-legacy-polyfill')
+  const legacyPolyfillSrc = legacyPolyfill?.getAttribute('src')
+
+  const legacyEntry = document.getElementById('vite-legacy-entry')
+  const legacyEntrySrc = legacyEntry?.getAttribute('data-src')
+
   if (legacyPolyfill) {
-    legacyPolyfill.setAttribute('data-src', legacyPolyfill.getAttribute('src'))
+    legacyPolyfill.setAttribute('data-src', legacyPolyfillSrc)
     legacyPolyfill.removeAttribute('src')
     legacyPolyfill.innerHTML = `!(function() {
       var e = document.createElement('script')
-      e.src = ${publicPath} + document.getElementById('vite-legacy-polyfill').getAttribute('data-src');
+      e.src = ${publicPath} + "${legacyPolyfillSrc}";
       e.onload = function() {
-        System.import(${publicPath}+document.getElementById('vite-legacy-entry').getAttribute('data-src'))
+        System.import(${publicPath} + "${legacyEntrySrc}")
       };
       document.body.appendChild(e)
     })();`
   }
-  const legacyEntry = document.getElementById('vite-legacy-entry')
   if (legacyEntry) {
     legacyEntry.innerHTML = ''
   }


### PR DESCRIPTION
since data-src is a non-standard attribute, micro-zoe/micro-app does not do anything about it during their js sandbox processing. this causes legayPolyfill to fail