### PR TITLE
Fix template literal asset paths for Vite 8

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -40,5 +40,5 @@ export function replaceInStringLiteral(literal: StringLiteral, base: string, pla
 
 export function replaceInTemplateElement(element: TemplateElement, base: string, placeholder: string): string {
   const regex = new RegExp(base, 'g');
-  return element.raw.replace(regex, () => '/${' + placeholder + '}/');
+  return element.raw.replace(regex, () => '${' + placeholder + '}/');
 }

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -43,18 +43,24 @@ describe('transform', () => {
   test('transformChunk-template-literal', async () => {
     const code = 'var foo=function(part1,part2){return \`${part1}/__dynamic_base__/test/${part2}\`;}';
     const result = await transformChunk(code, options);
-    expect(result).toEqual('var foo=function(part1,part2){return \`$\{part1}/${window.__dynamic_base__}/test/${part2}\`;}');
+    expect(result).toEqual('var foo=function(part1,part2){return \`$\{part1}${window.__dynamic_base__}/test/${part2}\`;}');
   })
 
   test('transformChunk-template-literal-with-multiple-elements', async () => {
     const code = "var reportError=function(e){return \`Couldn't find /__dynamic_base__/assets/${filename1} or /__dynamic_base__/assets/${filename2}\`;}";
     const result = await transformChunk(code, options);
-    expect(result).toEqual("var reportError=function(e){return `Couldn't find /${window.__dynamic_base__}/assets/${filename1} or /${window.__dynamic_base__}/assets/${filename2}`;}");
+    expect(result).toEqual("var reportError=function(e){return `Couldn't find ${window.__dynamic_base__}/assets/${filename1} or ${window.__dynamic_base__}/assets/${filename2}`;}");
   })
 
   test('transformChunk-mixed-strings-and-templates', async () => {
     const code = "const someString = \"Hello World!\"; const someTemplate = \`${Math.random()} is a random number.\`; const myPath = `/${someVar}/__dynamic_base__/image.png`; const strPath = '/assets/__dynamic_base__/image2.png';";
     const result = await transformChunk(code, options);
-    expect(result).toEqual("const someString = \"Hello World!\"; const someTemplate = \`${Math.random()} is a random number.\`; const myPath = `/${someVar}/${window.__dynamic_base__}/image.png`; const strPath = '/assets'+window.__dynamic_base__+'/image2.png';")
+    expect(result).toEqual("const someString = \"Hello World!\"; const someTemplate = \`${Math.random()} is a random number.\`; const myPath = `/${someVar}${window.__dynamic_base__}/image.png`; const strPath = '/assets'+window.__dynamic_base__+'/image2.png';")
+  })
+
+  test('transformChunk-vite8-template-asset-url', async () => {
+    const code = "const iconUrl = `/__dynamic_base__/assets/icon.svg`"
+    const result = await transformChunk(code, options)
+    expect(result).toEqual("const iconUrl = `${window.__dynamic_base__}/assets/icon.svg`")
   })
 })


### PR DESCRIPTION
## Summary
- fix template literal replacements so dynamic base paths don't emit `//assets/...` at the site root
- add coverage for template literal asset URLs emitted by Vite 8 / Rolldown

## Testing
- pnpm build
- pnpm test